### PR TITLE
[vizwiz-17] Rename showDataLayer to addressSearchPopupDataSourceUid

### DIFF
--- a/src/components/mapeditor.vue
+++ b/src/components/mapeditor.vue
@@ -81,7 +81,7 @@
           <label class="uk-form-label" for="data-show-layer">Show data from layer</label>
           <div class="uk-form-controls">
             <select
-              v-model="showDataLayer"
+              v-model="addressSearchPopupDataSourceUid"
               class="uk-select"
               id="data-show-layer"
               :disabled="!searchForAddress"
@@ -159,7 +159,7 @@ export default {
       searchForAddress: false,
       zoomToAddress: false,
       placeholderText: 'Search for an address...',
-      showDataLayer: '',
+      addressSearchPopupDataSourceUid: '',
       showZoomControl: false,
       showLegend: false,
     }
@@ -169,11 +169,11 @@ export default {
     this.searchForAddress = this.initialSearchForAddress
     this.zoomToAddress = this.initialZoomToAddress
     this.placeholderText = this.initialPlaceholderText
-    this.showDataLayer = this.initialShowDataLayer
+    this.addressSearchPopupDataSourceUid = this.initialShowDataLayer
     this.showZoomControl = this.initialShowZoomControl
     this.showLegend = this.initialShowLegend
-    if (this.showDataLayer === '') {
-      this.showDataLayer = Object.keys(this.dataLayers)[0]
+    if (this.addressSearchPopupDataSourceUid === '') {
+      this.addressSearchPopupDataSourceUid = Object.keys(this.dataLayers)[0]
     }
   },
   methods: {
@@ -189,7 +189,7 @@ export default {
         searchForAddress: this.searchForAddress,
         zoomToAddress: this.zoomToAddress,
         placeholderText: this.placeholderText,
-        showDataLayer: this.showDataLayer,
+        addressSearchPopupDataSourceUid: this.addressSearchPopupDataSourceUid,
       }
     },
     onSave (data) {
@@ -200,11 +200,11 @@ export default {
       this.searchForAddress = this.initialSearchForAddress
       this.zoomToAddress = this.initialZoomToAddress
       this.placeholderText = this.initialPlaceholderText
-      this.showDataLayer = this.initialShowDataLayer
+      this.addressSearchPopupDataSourceUid = this.initialShowDataLayer
       this.showZoomControl = this.initialShowZoomControl
       this.showLegend = this.initialShowLegend
-      if (this.showDataLayer === '') {
-        this.showDataLayer = Object.keys(this.dataLayers)[0]
+      if (this.addressSearchPopupDataSourceUid === '') {
+        this.addressSearchPopupDataSourceUid = Object.keys(this.dataLayers)[0]
       }
       this.$emit('cancel')
     },

--- a/src/components/store.js
+++ b/src/components/store.js
@@ -126,7 +126,7 @@ const store = new Vuex.Store({
         searchForAddress: map.searchForAddress,
         zoomToAddress: map.zoomToAddress,
         placeholderText: map.placeholderText,
-        showDataLayer: map.showDataLayer,
+        addressSearchPopupDataSourceUid: map.addressSearchPopupDataSourceUid,
       }
     },
   },

--- a/src/components/vizwiz.vue
+++ b/src/components/vizwiz.vue
@@ -122,7 +122,7 @@ export default {
               searchForAddress: item.searchForAddress,
               zoomToAddress: item.zoomToAddress,
               placeholderText: item.placeholderText,
-              showDataLayer: item.showDataLayer || this.$store.getters.allDataSources[0],
+              addressSearchPopupDataSourceUid: item.addressSearchPopupDataSourceUid || this.$store.getters.allDataSources[0],
             }
             this.$store.dispatch('updateMap', tempMap)
           }
@@ -185,7 +185,7 @@ export default {
         map.initialSearchForAddress = this.maps[0].searchForAddress
         map.initialZoomToAddress = this.maps[0].zoomToAddress
         map.initialPlaceholderText = this.maps[0].placeholderText
-        map.initialShowDataLayer = this.maps[0].showDataLayer
+        map.initialShowDataLayer = this.maps[0].addressSearchPopupDataSourceUid
         map.initialShowZoomControl = this.maps[0].showZoomControl
         map.initialShowLegend = this.maps[0].showLegend
       }


### PR DESCRIPTION
Example output:

```json
{
    "vizId": "WzLHSkyR3zgcisOfKk5YC",
    "title": "",
    "description": "",
    "dataSources": [
        {
            "uid": "ESkEdAMLocl7XfdODRnoV",
            "icon": "https://patterns.boston.gov/images/global/icons/mapping/waypoint-charles-blue.svg",
            "polygonStyle": {
                "uid": "default",
                "color": "#0C2639",
                "hoverColor": "#FB4D42"
            },
            "popover": "",
            "attributes": {
                "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/ArcGIS/rest/services/2016_Marathon_Traffic_Advisory/FeatureServer",
                "layer": 0
            },
            "legendLabel": ""
        }
    ],
    "maps": [
        {
            "uid": "oSL86ZZMaeR7n~ErRoud2",
            "latitude": 42.347316,
            "longitude": -71.065227,
            "zoom": 12,
            "showZoomControl": true,
            "showLegend": true,
            "findUserLocation": true,
            "searchForAddress": true,
            "zoomToAddress": true,
            "placeholderText": "Search for an address...",
            "addressSearchPopupDataSourceUid": "ESkEdAMLocl7XfdODRnoV"
        }
    ]
}
```