### PR TITLE
Fixes paths to JSON-Schema docs

### DIFF
--- a/docs/jsonschema.md
+++ b/docs/jsonschema.md
@@ -4,11 +4,11 @@
 
 Initial development version
 
-<a href="../schema/viz-0.0.schema.json">viz-0.0.schema.json</a> (<a href="../vendor/docson/#../../schema/viz-0.0.schema.json">Documentation</a>)
+<a href="./schema/viz-0.0.schema.json">viz-0.0.schema.json</a> (<a href="./vendor/docson/#../../schema/viz-0.0.schema.json">Documentation</a>)
 
 ## Version 1
 
 First milestone release. Features support the City Council map.
 
-<a href="../schema/viz-1.0.schema.json">viz-1.0.schema.json</a> (<a href="../vendor/docson/#../../schema/viz-1.0.schema.json">Documentation</a>)
+<a href="./schema/viz-1.0.schema.json">viz-1.0.schema.json</a> (<a href="./vendor/docson/#../../schema/viz-1.0.schema.json">Documentation</a>)
 


### PR DESCRIPTION
The ..s worked locally because there wasn't a subpath. This fixes things
for GitHub pages, where these are at a subpath.